### PR TITLE
Add short name to flag bind

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	bind    = kingpin.Flag("bind", "addr to bind the server").Default(":9222").String()
+	bind    = kingpin.Flag("bind", "addr to bind the server").Short('b').Default(":9222").String()
 	version = "master"
 
 	re = regexp.MustCompile(`(?i)(Registry Expiry Date|paid-till|Expiration Date|Expiry.*|expires.*): (.*)`)


### PR DESCRIPTION
The README says:
> ./domain_exporter -b ":9222"

but there isn't a short name for the `bind` flag. 

Added the short name `b`.

@caarlos0  