### PR TITLE
domain_exporter was not working for .tw domains

### DIFF
--- a/client/whois.go
+++ b/client/whois.go
@@ -38,7 +38,7 @@ var (
 	}
 
 	// nolint: lll
-	re = regexp.MustCompile(`(?i)(Registry Expiry Date|paid-till|Expiration Date|Expiration Time|Expiry|expires|Expires|Expires On|expire|Renewal Date|Expire Date|Record expires on):?\s+(.*)`)
+	re = regexp.MustCompile(`(?i)(Registry Expiry Date|paid-till|Expiration Date|Expiration Time|Expiry date|Expiry|expires|Expires|Expires On|expire|Renewal Date|Expire Date|Record expires on):?\s+(.*)`)
 )
 
 type whoisClient struct {

--- a/client/whois_test.go
+++ b/client/whois_test.go
@@ -19,6 +19,7 @@ func TestWhoisParsing(t *testing.T) {
 		{domain: "google.de", err: "could not parse whois response"},
 		{domain: "nic.ua", err: ""},
 		{domain: "taiwannews.com.tw", err: ""},
+		{domain: "bbc.co.uk", err: ""},
 		// {domain: "watchub.pw", err: ""}, // TODO: this for some reason fails on travis
 	} {
 		tt := tt


### PR DESCRIPTION
None of the existing regex matches matched the string "Record expires on" - they do now.

It was necessary to make the `:` optional, as TWNIC does not use them.

I've removed the wildcards from `Expiry.*` and `expires.*` because the tests started failing with them for `domreg.lt` and `nic.ua`. Without the wildcards, the tests all pass.