### PR TITLE
Add docker builder step

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+_examples
+.git
+.gitignore
+.goreleaser.yml
+.travis.yml
+go.mod
+go.sum
+LICENSE.md
+README.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,2 @@
 _examples
 .git
-.gitignore
-.goreleaser.yml
-.travis.yml
-go.mod
-go.sum
-LICENSE.md
-README.md

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,14 @@
+FROM golang:1.11 as builder
+
+ENV GOBIN /go/bin
+
+COPY . .
+
+RUN go get \
+  && go build -o domain_exporter main.go
+
+FROM gcr.io/distroless/base
+EXPOSE 9222
+WORKDIR /
+COPY --from=builder /go/domain_exporter .
+ENTRYPOINT ["./domain_exporter"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,10 +1,12 @@
 FROM golang:1.11 as builder
 
 ENV GOBIN /go/bin
+ENV GO111MODULE on
 
+WORKDIR /go/src/github.com/caarlos0/domain_exporter
 COPY . .
 
-RUN go get \
+RUN go mod download \
   && go build -o domain_exporter main.go
 
 FROM gcr.io/distroless/base


### PR DESCRIPTION
I don't have Golang installed so I was forced to update `Dockefile` with intermediate builder container to actually build the image.

Sadly, `make setup` failed in container. I'm not even familiar with Golang, so I evaded copying stuff like `go.mod`, just put `*.go` files there and issued `go get && go build`. It worked.

This is definitely good practice to make build process independent from local environment, would be glad to hear your thoughts about improving this further.