### PR TITLE
feat: try registrar from response

### DIFF
--- a/internal/whois/whois.go
+++ b/internal/whois/whois.go
@@ -89,6 +89,12 @@ func (c whoisClient) request(domain, host string) (string, error) {
 		return "", err
 	}
 	body := string(resp.Body)
+
+	if host == "" {
+		// do not recurse
+		return body, nil
+	}
+
 	result := registrarRE.FindStringSubmatch(body)
 	if len(result) < 2 {
 		log.Debugf("couldn't find registrar url in whois response: %s", domain)

--- a/internal/whois/whois_test.go
+++ b/internal/whois/whois_test.go
@@ -4,12 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/common/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestWhoisParsing(t *testing.T) {
-	log.Base().SetLevel("debug")
 	for _, tt := range []struct {
 		domain string
 		err    string

--- a/internal/whois/whois_test.go
+++ b/internal/whois/whois_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/common/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestWhoisParsing(t *testing.T) {
+	log.Base().SetLevel("debug")
 	for _, tt := range []struct {
 		domain string
 		err    string


### PR DESCRIPTION
if the response has a string

```
Registrar WHOIS Server: host
```

Do another whois request using to that host.

closes #88 