### PR TITLE
feat: Export metrics for domains provided from configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ On the prometheus settings, add the `domain_exporter` prober:
   relabel_configs:
     - source_labels: [__address__]
       target_label: __param_target
-    - source_labels: [__param_target]
-      target_label: domain
     - target_label: __address__
       replacement: localhost:9222 # domain_exporter address
   static_configs:
@@ -39,6 +37,18 @@ It works more or less like prometheus's
 Alerting rules examples can be found on the
 [_examples](https://github.com/caarlos0/domain_exporter/tree/master/_examples)
 folder.
+
+You can configure `domain_exporter` to always export metrics for specific domains.
+Create configuration file:
+```yaml
+domains:
+- google.com
+- reddit.com
+```
+And pass file path as agrument to `domain_exporter`:
+```
+domain_exporter --config domains.yaml
+```
 
 ## Install
 

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,5 @@ require (
 	github.com/rs/zerolog v1.23.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -499,6 +499,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/client/cache_test.go
+++ b/internal/client/cache_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -13,18 +14,19 @@ type testClient struct {
 	result *time.Time
 }
 
-func (f testClient) ExpireTime(_ string) (time.Time, error) {
+func (f testClient) ExpireTime(_ context.Context, _ string) (time.Time, error) {
 	return *f.result, nil
 }
 
 type errTestClient struct {
 }
 
-func (f errTestClient) ExpireTime(_ string) (time.Time, error) {
+func (f errTestClient) ExpireTime(_ context.Context, _ string) (time.Time, error) {
 	return time.Now(), fmt.Errorf("failed to get domain info blah")
 }
 
 func TestCachedClient(t *testing.T) {
+	ctx := context.Background()
 	cache := cache.New(1*time.Minute, 1*time.Minute)
 	expected := time.Now()
 	domain := "foo.bar"
@@ -33,7 +35,7 @@ func TestCachedClient(t *testing.T) {
 
 	// test getting from out fake client
 	t.Run("get fresh", func(t *testing.T) {
-		res, err := cli.ExpireTime(domain)
+		res, err := cli.ExpireTime(ctx, domain)
 		require.NoError(t, err)
 		require.Equal(t, expected, res)
 	})
@@ -43,7 +45,7 @@ func TestCachedClient(t *testing.T) {
 	t.Run("get from cache", func(t *testing.T) {
 		oldExpected := expected
 		expected = time.Now()
-		res, err := cli.ExpireTime(domain)
+		res, err := cli.ExpireTime(ctx, domain)
 		require.NoError(t, err)
 		require.Equal(t, oldExpected, res)
 	})
@@ -52,7 +54,7 @@ func TestCachedClient(t *testing.T) {
 	// from the fake client
 	t.Run("flush cache", func(t *testing.T) {
 		cache.Flush()
-		res, err := cli.ExpireTime(domain)
+		res, err := cli.ExpireTime(ctx, domain)
 		require.NoError(t, err)
 		require.Equal(t, expected, res)
 	})
@@ -61,9 +63,9 @@ func TestCachedClient(t *testing.T) {
 		cache.Flush()
 
 		cli := NewCachedClient(errTestClient{}, cache)
-		_, err := cli.ExpireTime(domain)
+		_, err := cli.ExpireTime(ctx, domain)
 		require.Error(t, err)
-		_, err = cli.ExpireTime(domain)
+		_, err = cli.ExpireTime(ctx, domain)
 		require.Error(t, err)
 		cached, got := cache.Get(domain)
 		require.Nil(t, cached)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,8 +1,11 @@
 package client
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // Client is a DNS client impl.
 type Client interface {
-	ExpireTime(domain string) (time.Time, error)
+	ExpireTime(ctx context.Context, domain string) (time.Time, error)
 }

--- a/internal/client/multi.go
+++ b/internal/client/multi.go
@@ -1,14 +1,17 @@
 package client
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type multiClient []Client
 
-func (clients multiClient) ExpireTime(domain string) (time.Time, error) {
+func (clients multiClient) ExpireTime(ctx context.Context, domain string) (time.Time, error) {
 	var t time.Time
 	var err error
 	for _, client := range clients {
-		t, err = client.ExpireTime(domain)
+		t, err = client.ExpireTime(ctx, domain)
 		if err == nil {
 			break
 		}

--- a/internal/client/multi_test.go
+++ b/internal/client/multi_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -10,31 +11,32 @@ import (
 
 type clifail int
 
-func (clifail) ExpireTime(domain string) (time.Time, error) {
+func (clifail) ExpireTime(_ context.Context, domain string) (time.Time, error) {
 	return time.Time{}, errors.New("foo")
 }
 
 type clisuccess time.Time
 
-func (c clisuccess) ExpireTime(domain string) (time.Time, error) {
+func (c clisuccess) ExpireTime(_ context.Context, domain string) (time.Time, error) {
 	return time.Time(c), nil
 }
 
 func TestMulti(t *testing.T) {
+	ctx := context.Background()
 	t.Run("first client succeed", func(t *testing.T) {
 		expected := time.Now()
-		expire, err := NewMultiClient(clisuccess(expected), clifail(0)).ExpireTime("a")
+		expire, err := NewMultiClient(clisuccess(expected), clifail(0)).ExpireTime(ctx, "a")
 		require.NoError(t, err)
 		require.Equal(t, expected, expire)
 	})
 	t.Run("last client succeed", func(t *testing.T) {
 		expected := time.Now()
-		expire, err := NewMultiClient(clifail(0), clifail(0), clisuccess(expected)).ExpireTime("a")
+		expire, err := NewMultiClient(clifail(0), clifail(0), clisuccess(expected)).ExpireTime(ctx, "a")
 		require.NoError(t, err)
 		require.Equal(t, expected, expire)
 	})
 	t.Run("no client succeed", func(t *testing.T) {
-		expire, err := NewMultiClient(clifail(0), clifail(0), clifail(0)).ExpireTime("a")
+		expire, err := NewMultiClient(clifail(0), clifail(0), clifail(0)).ExpireTime(ctx, "a")
 		require.EqualError(t, err, "foo")
 		require.Zero(t, expire)
 	})

--- a/internal/collector/domain_test.go
+++ b/internal/collector/domain_test.go
@@ -19,8 +19,8 @@ func TestCollectorError(t *testing.T) {
 	multi := client.NewMultiClient(rdap.NewClient(), whois.NewClient())
 	testCollector(t, NewDomainCollector(multi, "fake.foo"), func(t *testing.T, status int, body string) {
 		require.Equal(t, 200, status)
-		require.Contains(t, body, "domain_probe_success 0")
-		require.Contains(t, body, "domain_expiry_days -1")
+		require.Contains(t, body, "domain_probe_success{domain=\"fake.foo\"} 0")
+		require.Contains(t, body, "domain_expiry_days{domain=\"fake.foo\"} -1")
 	})
 }
 
@@ -28,8 +28,8 @@ func TestNotExpired(t *testing.T) {
 	multi := client.NewMultiClient(rdap.NewClient(), whois.NewClient())
 	testCollector(t, NewDomainCollector(multi, "goreleaser.com"), func(t *testing.T, status int, body string) {
 		require.Equal(t, 200, status)
-		require.Contains(t, body, "domain_probe_success 1")
-		require.Regexp(t, regexp.MustCompile(`domain_expiry_days \d+`), body)
+		require.Contains(t, body, "domain_probe_success{domain=\"goreleaser.com\"} 1")
+		require.Regexp(t, regexp.MustCompile(`domain_expiry_days{domain=\"goreleaser.com\"} \d+`), body)
 	})
 }
 

--- a/internal/rdap/rdap_test.go
+++ b/internal/rdap/rdap_test.go
@@ -1,6 +1,7 @@
 package rdap
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -30,7 +31,7 @@ func TestRdapParsing(t *testing.T) {
 		tt := tt
 		t.Run(tt.domain, func(t *testing.T) {
 			t.Parallel()
-			expiry, err := NewClient().ExpireTime(tt.domain)
+			expiry, err := NewClient().ExpireTime(context.Background(), tt.domain)
 			if tt.err == "" {
 				require.NoError(t, err)
 				require.True(t, time.Since(expiry).Hours() < 0, "domain must not be expired")

--- a/internal/refresher/refresher.go
+++ b/internal/refresher/refresher.go
@@ -1,0 +1,50 @@
+package refresher
+
+import (
+	"context"
+	"time"
+
+	"github.com/caarlos0/domain_exporter/internal/client"
+	"github.com/rs/zerolog/log"
+)
+
+type refresher struct {
+	interval time.Duration
+	client   client.Client
+	domains  []string
+}
+
+func New(interval time.Duration, client client.Client, domains ...string) refresher {
+	return refresher{
+		interval: interval,
+		client:   client,
+		domains:  domains,
+	}
+}
+
+func (r refresher) Run(ctx context.Context) {
+	log.Info().Msg("run refresher")
+
+	ticker := time.NewTicker(r.interval)
+	r.Refresh(ctx)
+
+	select {
+	case <-ticker.C:
+		r.Refresh(ctx)
+	case <-ctx.Done():
+		log.Info().Msg("refresher is finished")
+		return
+	}
+}
+
+func (r refresher) Refresh(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel()
+
+	for _, domain := range r.domains {
+		if _, err := r.client.ExpireTime(ctx, domain); err != nil {
+			log.Error().Err(err).Msgf("failed to get expire time for %s", domain)
+		}
+	}
+	log.Debug().Msg("refresh is done")
+}

--- a/internal/refresher/refresher_test.go
+++ b/internal/refresher/refresher_test.go
@@ -1,0 +1,43 @@
+package refresher
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeOk struct {
+}
+
+func (fakeOk) ExpireTime(ctx context.Context, domain string) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+type fakeFail struct {
+}
+
+func (fakeFail) ExpireTime(ctx context.Context, domain string) (time.Time, error) {
+	return time.Time{}, errors.New("foo")
+}
+
+func Test_refresher_Refresh(t *testing.T) {
+	tests := []struct {
+		name      string
+		refresher refresher
+	}{
+		{
+			name:      "refresh is ok",
+			refresher: New(time.Second, fakeOk{}, "foo.com"),
+		},
+		{
+			name:      "refresh is failed",
+			refresher: New(time.Second, fakeFail{}, "foo.com"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.refresher.Refresh(context.Background())
+		})
+	}
+}

--- a/internal/safeconfig/safeconfig.go
+++ b/internal/safeconfig/safeconfig.go
@@ -1,0 +1,50 @@
+package safeconfig
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v2"
+)
+
+type SafeConfig struct {
+	Domains []string `yaml:"domains"`
+}
+
+func New(pathToFile string) (SafeConfig, error) {
+	cfg := SafeConfig{}
+	if pathToFile == "" {
+		log.Debug().Msg("config file path is empty, skip loading")
+		return cfg, nil
+	}
+
+	if err := cfg.Reload(pathToFile); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+func (cfg *SafeConfig) Reload(pathToFile string) error {
+	log.Info().Msgf("trying to load config from file %s", pathToFile)
+
+	filename, err := filepath.Abs(pathToFile)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path of file %s: %w", pathToFile, err)
+	}
+	log.Debug().Msgf("absolute path of config file is %s", filename)
+
+	yamlFile, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	err = yaml.Unmarshal(yamlFile, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal file: %w", err)
+	}
+
+	log.Debug().Msgf("config file is loaded:\n %s", *cfg)
+	return nil
+}

--- a/internal/safeconfig/safeconfig_test.go
+++ b/internal/safeconfig/safeconfig_test.go
@@ -1,0 +1,113 @@
+package safeconfig
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/rs/zerolog/log"
+)
+
+func TestNew(t *testing.T) {
+	type args struct {
+		pathToFile string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    SafeConfig
+		wantErr bool
+	}{
+		{
+			name: "Empty file name. Default",
+			args: args{
+				"",
+			},
+			want:    SafeConfig{},
+			wantErr: false,
+		},
+		{
+			name: "Empty file name",
+			args: args{
+				"file-which-does-not-exist.yaml",
+			},
+			want:    SafeConfig{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := New(tt.args.pathToFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSafeConfig_Reload(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         SafeConfig
+		fileContent string
+		wantErr     bool
+	}{
+		{
+			name:        "Load empty file",
+			cfg:         SafeConfig{},
+			fileContent: "",
+			wantErr:     false,
+		},
+		{
+			name:        "yaml is not valid",
+			cfg:         SafeConfig{},
+			fileContent: "yaml is not correct",
+			wantErr:     true,
+		},
+		{
+			name: "Vaidd yaml",
+			cfg: SafeConfig{
+				Domains: []string{"google.com"},
+			},
+			fileContent: `
+domains:
+- google.com`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, err := ioutil.TempFile(os.TempDir(), "temp.*.yaml")
+			if err != nil {
+				log.Fatal().Err(err)
+			}
+			f, err := os.Create(file.Name())
+			if err != nil {
+				log.Fatal().Err(err)
+			}
+			defer f.Close()
+			log.Info().Msg(tt.fileContent)
+			_, err2 := f.WriteString(tt.fileContent)
+
+			if err2 != nil {
+				log.Fatal().Err(err)
+			}
+			defer os.Remove(file.Name())
+
+			cfg, err := New(file.Name())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SafeConfig.New() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(cfg, tt.cfg) {
+				t.Errorf("cfg is not equal:\n got %s\n expected: %s", cfg, tt.cfg)
+			}
+		})
+	}
+}

--- a/internal/whois/whois_test.go
+++ b/internal/whois/whois_test.go
@@ -1,6 +1,7 @@
 package whois
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -35,7 +36,7 @@ func TestWhoisParsing(t *testing.T) {
 		tt := tt
 		t.Run(tt.domain, func(t *testing.T) {
 			t.Parallel()
-			expiry, err := NewClient().ExpireTime(tt.domain)
+			expiry, err := NewClient().ExpireTime(context.Background(), tt.domain)
 			if tt.err == "" {
 				require.NoError(t, err)
 				require.True(t, time.Since(expiry).Hours() < 0, "domain must not be expired")

--- a/main.go
+++ b/main.go
@@ -1,15 +1,22 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"sync"
+	"syscall"
+	"time"
 
 	"github.com/alecthomas/kingpin"
 	"github.com/caarlos0/domain_exporter/internal/client"
 	"github.com/caarlos0/domain_exporter/internal/collector"
 	"github.com/caarlos0/domain_exporter/internal/rdap"
+	"github.com/caarlos0/domain_exporter/internal/refresher"
+	"github.com/caarlos0/domain_exporter/internal/safeconfig"
 	"github.com/caarlos0/domain_exporter/internal/whois"
 	cache "github.com/patrickmn/go-cache"
 	"github.com/prometheus/client_golang/prometheus"
@@ -20,11 +27,12 @@ import (
 
 // nolint: gochecknoglobals
 var (
-	bind     = kingpin.Flag("bind", "addr to bind the server").Short('b').Default(":9222").String()
-	debug    = kingpin.Flag("debug", "show debug logs").Default("false").Bool()
-	format   = kingpin.Flag("logFormat", "log format to use").Default("console").Enum("json", "console")
-	interval = kingpin.Flag("cache", "time to cache the result of whois calls").Default("2h").Duration()
-	version  = "master"
+	bind       = kingpin.Flag("bind", "addr to bind the server").Short('b').Default(":9222").String()
+	debug      = kingpin.Flag("debug", "show debug logs").Default("false").Bool()
+	format     = kingpin.Flag("logFormat", "log format to use").Default("console").Enum("json", "console")
+	interval   = kingpin.Flag("cache", "time to cache the result of whois calls").Default("2h").Duration()
+	configFile = kingpin.Flag("config", "configuration file").String()
+	version    = "master"
 )
 
 func main() {
@@ -47,12 +55,34 @@ func main() {
 	}
 
 	log.Info().Msgf("starting domain_exporter %s", version)
+	cfg, err := safeconfig.New(*configFile)
+	if err != nil {
+		log.Fatal().Err(err).Msg("error to create config")
+	}
+
+	wg := &sync.WaitGroup{}
+	defer wg.Wait()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	cache := cache.New(*interval, *interval)
-	whoisClient := client.NewCachedClient(whois.NewClient(), cache)
-	rdapClient := client.NewCachedClient(rdap.NewClient(), cache)
+	cli := client.NewMultiClient(rdap.NewClient(), whois.NewClient())
+	cachedClient := client.NewCachedClient(cli, cache)
+
+	if len(cfg.Domains) != 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			refresher.New(*interval, cachedClient, cfg.Domains...).Run(ctx)
+		}()
+
+		domainCollector := collector.NewDomainCollector(cachedClient, cfg.Domains...)
+		prometheus.DefaultRegisterer.MustRegister(domainCollector)
+	}
 
 	http.Handle("/metrics", promhttp.Handler())
-	http.HandleFunc("/probe", probeHandler(client.NewMultiClient(rdapClient, whoisClient)))
+	http.HandleFunc("/probe", probeHandler(cli))
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(
 			w, `
@@ -67,10 +97,42 @@ func main() {
 			`, urlPrefix,
 		)
 	})
-	log.Info().Msgf("listening on %s", *bind)
-	if err := http.ListenAndServe(*bind, nil); err != nil {
+
+	if err := runServerWithGracefullyShutdown(wg); err != nil {
 		log.Fatal().Err(err).Msg("error starting server")
 	}
+
+	log.Info().Msg("domain exporter is finished")
+}
+
+func runServerWithGracefullyShutdown(wg *sync.WaitGroup) error {
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGTERM)
+	signal.Notify(signalChan, syscall.SIGINT)
+
+	server := &http.Server{Addr: *bind}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		sig := <-signalChan
+
+		log.Warn().Msgf("got %s signal. Shutdown", sig)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		defer cancel()
+
+		if err := server.Shutdown(ctx); err != nil {
+			log.Error().Err(err).Msg("failed to shutdown http server")
+		}
+	}()
+
+	log.Info().Msgf("listening on %s", *bind)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return err
+	}
+
+	return nil
 }
 
 func probeHandler(cli client.Client) http.HandlerFunc {


### PR DESCRIPTION
First of all, thank you for domain exporter. Great work!

I'm developing Kubernetes [helm chart](https://github.com/zifter/domain-exporter-helm) to provide easily information about domain expiration from the scratch - metrics, alerts and grafana dashboard. 

Prometheus will discover services to exporter metrics via ServiceMonitor. ServiceMonitor allows adding new service to scrape without changing Prometheus scrape config. And, unfortunately, this is no opportunity to specify targets, like in Prometheus scrape config. 

Previously, I used exporter https://github.com/shift/domain_exporter. This exporter allows specifying domains from configuration file, so it always exports metrics from /metrics endpoint. 
But repo is not supported by owner now.

I would like to use your exporter in this helm chart.
In order to make it possible, it would be great to use something similar to configuration file. 

This is pr contains a bunch of changes to do that:
1. Create SafeConfig with specifying domains to export metrics;
2. Create goroutine to refresh in background expiration time (prevent lag while metrics collecting):
2a. Run refresher goroutine
2b. Obligatory to use context with timeout while getting expiration time.
2c. Create gracefully shutdown of http server.
3. Update README.md with description, how to use it
4. Fix "accept interfaces, return structs" issues
5. Of course, necessary unit tests was added.

Application still works as previously if config file path is not passed.
The main change that is domain label will be provided out of the box.

Please, review this changes and give me feedback about them.