### PR TITLE
fix: whois request for capitalized and unicode domains

### DIFF
--- a/internal/whois/whois.go
+++ b/internal/whois/whois.go
@@ -10,6 +10,7 @@ import (
 	"github.com/caarlos0/domain_exporter/internal/client"
 	"github.com/domainr/whois"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/net/idna"
 )
 
 // nolint: gochecknoglobals
@@ -81,8 +82,15 @@ func (c whoisClient) ExpireTime(ctx context.Context, domain string) (time.Time, 
 }
 
 func (c whoisClient) request(ctx context.Context, domain, host string) (string, error) {
+	normalizedDomain := strings.ToLower(domain)
+
+	normalizedDomain, err := idna.ToASCII(normalizedDomain)
+	if err != nil {
+		return "", fmt.Errorf("failed to normalize domain name: %w", err)
+	}
+
 	req := &whois.Request{
-		Query: domain,
+		Query: normalizedDomain,
 		Host:  host,
 	}
 	if err := req.Prepare(); err != nil {

--- a/internal/whois/whois_test.go
+++ b/internal/whois/whois_test.go
@@ -24,7 +24,7 @@ func TestWhoisParsing(t *testing.T) {
 		{domain: "bbc.co.uk", err: ""},
 		{domain: "google.sk", err: ""},
 		{domain: "google.ro", err: ""},
-		// {domain: "google.pt", err: ""}, // timeouts all the time
+		{domain: "google.pt", err: "i/o timeout"},
 		{domain: "google.it", err: ""},
 		{domain: "watchub.pw", err: ""},
 		{domain: "google.co.id", err: ""},
@@ -32,11 +32,17 @@ func TestWhoisParsing(t *testing.T) {
 		{domain: "google.jp", err: ""},
 		{domain: "microsoft.im", err: ""},
 		{domain: "google.rs", err: ""},
+		{domain: "мвд.рф", err: ""},
+		{domain: "МВД.РФ", err: ""},
+		{domain: "GOOGLE.RS", err: ""},
 	} {
 		tt := tt
 		t.Run(tt.domain, func(t *testing.T) {
 			t.Parallel()
-			expiry, err := NewClient().ExpireTime(context.Background(), tt.domain)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			expiry, err := NewClient().ExpireTime(ctx, tt.domain)
 			if tt.err == "" {
 				require.NoError(t, err)
 				require.True(t, time.Since(expiry).Hours() < 0, "domain must not be expired")


### PR DESCRIPTION
According to this comment: 
https://github.com/zonedb/zonedb/blob/main/zone.go#L172
given domain must be normalized by the client (lowercase, ASCII-encoded).

So, lowercasing and ASCII-encoded was added before preparing whois request.
As a result, domain-exporter will be able to process unicode domains  in zones like here:
https://github.com/zonedb/zonedb/blob/main/zones.go#L1682
