### PR TITLE
Add expiry RE for domain .co.th :tea:

### DIFF
--- a/internal/whois/whois.go
+++ b/internal/whois/whois.go
@@ -48,10 +48,11 @@ var (
 		"2006-01-02 15:04:05 (UTC+8)", // .tw
 		"02/01/2006 15:04:05",         // .im
 		"02.01.2006 15:04:05",         // .rs
+		"01 Feb 2006",                 // .co.th
 	}
 
 	// nolint: lll
-	expiryRE    = regexp.MustCompile(`(?i)(Registrar Registration Expiration Date|expire-date|Valid Until|Expire Date|Registry Expiry Date|paid-till|Expiration Date|Expiration Time|Expiry date|Expiry|Expires On|expires|Expires|expire|Renewal Date|Record expires on)\]?:?\s?(.*)`)
+	expiryRE    = regexp.MustCompile(`(?i)(Registrar Registration Expiration Date|expire-date|Valid Until|Expire Date|Registry Expiry Date|paid-till|Expiration Date|Expiration Time|Expiry date|Expiry|Expires On|expires|Expires|expire|Renewal Date|Record expires on|Exp date)\]?:?\s?(.*)`)
 	registrarRE = regexp.MustCompile(`(?i)Registrar WHOIS Server: (.*)`)
 )
 

--- a/internal/whois/whois_test.go
+++ b/internal/whois/whois_test.go
@@ -35,7 +35,7 @@ func TestWhoisParsing(t *testing.T) {
 		{domain: "мвд.рф", err: ""},
 		{domain: "МВД.РФ", err: ""},
 		{domain: "GOOGLE.RS", err: ""},
-		{domain: "thnic.co.th", err: ""},
+		{domain: "google.co.th", err: ""},
 	} {
 		tt := tt
 		t.Run(tt.domain, func(t *testing.T) {

--- a/internal/whois/whois_test.go
+++ b/internal/whois/whois_test.go
@@ -35,6 +35,7 @@ func TestWhoisParsing(t *testing.T) {
 		{domain: "мвд.рф", err: ""},
 		{domain: "МВД.РФ", err: ""},
 		{domain: "GOOGLE.RS", err: ""},
+		{domain: "thnic.co.th", err: ""},
 	} {
 		tt := tt
 		t.Run(tt.domain, func(t *testing.T) {


### PR DESCRIPTION
I've already included a regular expression to detect the expiry of the TLD .co.th.

You may try this domain thnic.co.th, and an example whois result is shown below.

```bash
Whois Server Version 2.1.6

Domain Name:                THNIC.CO.TH
Registrar:                  THNIC
Name Server:                C-NS.THNIC.CO.TH
Name Server:                B-NS.THNIC.CO.TH
Name Server:                A-NS.THNIC.CO.TH
DNSSEC:                     signedDelegation
Status:                     ACTIVE
Updated date:               16 Sep 2020
Created date:               30 Mar 1999
Exp date:                   01 Apr 2030
Domain Holder Organization: T.H.NIC Co.,Ltd. (บริษัท ที.เอช.นิค จำกัด)
Domain Holder Street:       Personal Information*
Domain Holder Country:      TH

Tech Contact:               Personal Information*
Tech Organization:          Personal Information*
Tech Street:                Personal Information*
Tech Country:               Personal Information*
```