### PR TITLE
add support for using custom whois host per domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 bin/
 .idea/*
 domain_exporter
+config.yaml

--- a/internal/client/cache.go
+++ b/internal/client/cache.go
@@ -21,14 +21,14 @@ func NewCachedClient(client Client, cache *cache.Cache) Client {
 	}
 }
 
-func (c cachedClient) ExpireTime(ctx context.Context, domain string) (time.Time, error) {
+func (c cachedClient) ExpireTime(ctx context.Context, domain string, host string) (time.Time, error) {
 	cached, found := c.cache.Get(domain)
 	if found {
 		log.Debug().Msgf("using result from cache for %s", domain)
 		return cached.(time.Time), nil
 	}
 	log.Debug().Msgf("getting live result for %s", domain)
-	live, err := c.client.ExpireTime(ctx, domain)
+	live, err := c.client.ExpireTime(ctx, domain, host)
 	if err == nil {
 		log.Debug().Msgf("caching result for %s", domain)
 		c.cache.Set(domain, live, cache.DefaultExpiration)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,5 +7,5 @@ import (
 
 // Client is a DNS client impl.
 type Client interface {
-	ExpireTime(ctx context.Context, domain string) (time.Time, error)
+	ExpireTime(ctx context.Context, domain string, host string) (time.Time, error)
 }

--- a/internal/client/multi.go
+++ b/internal/client/multi.go
@@ -7,11 +7,11 @@ import (
 
 type multiClient []Client
 
-func (clients multiClient) ExpireTime(ctx context.Context, domain string) (time.Time, error) {
+func (clients multiClient) ExpireTime(ctx context.Context, domain string, host string) (time.Time, error) {
 	var t time.Time
 	var err error
 	for _, client := range clients {
-		t, err = client.ExpireTime(ctx, domain)
+		t, err = client.ExpireTime(ctx, domain, host)
 		if err == nil {
 			break
 		}

--- a/internal/client/multi_test.go
+++ b/internal/client/multi_test.go
@@ -11,13 +11,13 @@ import (
 
 type clifail int
 
-func (clifail) ExpireTime(_ context.Context, domain string) (time.Time, error) {
+func (clifail) ExpireTime(_ context.Context, domain string, host string) (time.Time, error) {
 	return time.Time{}, errors.New("foo")
 }
 
 type clisuccess time.Time
 
-func (c clisuccess) ExpireTime(_ context.Context, domain string) (time.Time, error) {
+func (c clisuccess) ExpireTime(_ context.Context, domain string, host string) (time.Time, error) {
 	return time.Time(c), nil
 }
 
@@ -26,20 +26,20 @@ func TestMulti(t *testing.T) {
 	t.Run("first client succeed", func(t *testing.T) {
 		is := is.New(t)
 		expected := time.Now()
-		expire, err := NewMultiClient(clisuccess(expected), clifail(0)).ExpireTime(ctx, "a")
+		expire, err := NewMultiClient(clisuccess(expected), clifail(0)).ExpireTime(ctx, "a", "")
 		is.NoErr(err)              // expected no error
 		is.Equal(expected, expire) // expeted the same result
 	})
 	t.Run("last client succeed", func(t *testing.T) {
 		is := is.New(t)
 		expected := time.Now()
-		expire, err := NewMultiClient(clifail(0), clifail(0), clisuccess(expected)).ExpireTime(ctx, "a")
+		expire, err := NewMultiClient(clifail(0), clifail(0), clisuccess(expected)).ExpireTime(ctx, "a", "")
 		is.NoErr(err)              // expected no error
 		is.Equal(expected, expire) // expeted the same result
 	})
 	t.Run("no client succeed", func(t *testing.T) {
 		is := is.New(t)
-		expire, err := NewMultiClient(clifail(0), clifail(0), clifail(0)).ExpireTime(ctx, "a")
+		expire, err := NewMultiClient(clifail(0), clifail(0), clifail(0)).ExpireTime(ctx, "a", "")
 		is.True(err != nil)           // expected an error
 		is.Equal(err.Error(), "foo")  // expected the correct error msg
 		is.Equal(expire, time.Time{}) // expected a zeroed result

--- a/internal/collector/domain_test.go
+++ b/internal/collector/domain_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/caarlos0/domain_exporter/internal/client"
 	"github.com/caarlos0/domain_exporter/internal/rdap"
+	"github.com/caarlos0/domain_exporter/internal/safeconfig"
 	"github.com/caarlos0/domain_exporter/internal/whois"
 	"github.com/matryer/is"
 	"github.com/prometheus/client_golang/prometheus"
@@ -19,7 +20,7 @@ import (
 func TestCollectorError(t *testing.T) {
 	is := is.New(t)
 	multi := client.NewMultiClient(rdap.NewClient(), whois.NewClient())
-	testCollector(t, NewDomainCollector(multi, "fake.foo"), func(t *testing.T, status int, body string) {
+	testCollector(t, NewDomainCollector(multi, safeconfig.Domain{Name: "fake.foo", Host: ""}), func(t *testing.T, status int, body string) {
 		is.Equal(200, status)                                                          // request should succeed
 		is.True(strings.Contains(body, "domain_probe_success{domain=\"fake.foo\"} 0")) // probe should succeed
 		is.True(strings.Contains(body, "domain_expiry_days{domain=\"fake.foo\"} -1"))  // should contain domain expiry
@@ -29,7 +30,7 @@ func TestCollectorError(t *testing.T) {
 func TestNotExpired(t *testing.T) {
 	is := is.New(t)
 	multi := client.NewMultiClient(rdap.NewClient(), whois.NewClient())
-	testCollector(t, NewDomainCollector(multi, "goreleaser.com"), func(t *testing.T, status int, body string) {
+	testCollector(t, NewDomainCollector(multi, safeconfig.Domain{Name: "goreleaser.com", Host: ""}), func(t *testing.T, status int, body string) {
 		is.Equal(200, status)                                                                                   // srequest hould succeed
 		is.True(strings.Contains(body, "domain_probe_success{domain=\"goreleaser.com\"} 1"))                    // probe should succeed
 		is.True(regexp.MustCompile(`domain_expiry_days{domain=\"goreleaser.com\"} \d+`).FindString(body) != "") // should contain domain expiry

--- a/internal/rdap/rdap.go
+++ b/internal/rdap/rdap.go
@@ -52,7 +52,7 @@ func NewClient() client.Client {
 	return rdapClient{}
 }
 
-func (rdapClient) ExpireTime(ctx context.Context, domain string) (time.Time, error) {
+func (rdapClient) ExpireTime(ctx context.Context, domain string, host string) (time.Time, error) {
 	log.Debug().Msgf("trying rdap client for %s", domain)
 	req := &rdap.Request{
 		Type:  rdap.DomainRequest,

--- a/internal/rdap/rdap_test.go
+++ b/internal/rdap/rdap_test.go
@@ -35,7 +35,7 @@ func TestRdapParsing(t *testing.T) {
 		t.Run(tt.domain, func(t *testing.T) {
 			t.Parallel()
 			is := is.New(t)
-			expiry, err := NewClient().ExpireTime(context.Background(), tt.domain)
+			expiry, err := NewClient().ExpireTime(context.Background(), tt.domain, "")
 			if tt.err == "" {
 				is.NoErr(err)                           // should not err
 				is.True(time.Since(expiry).Hours() < 0) // domain must not be expired

--- a/internal/refresher/refresher.go
+++ b/internal/refresher/refresher.go
@@ -5,16 +5,17 @@ import (
 	"time"
 
 	"github.com/caarlos0/domain_exporter/internal/client"
+	"github.com/caarlos0/domain_exporter/internal/safeconfig"
 	"github.com/rs/zerolog/log"
 )
 
 type Refresher struct {
 	ticker  *time.Ticker
 	client  client.Client
-	domains []string
+	domains []safeconfig.Domain
 }
 
-func New(interval time.Duration, client client.Client, domains ...string) Refresher {
+func New(interval time.Duration, client client.Client, domains ...safeconfig.Domain) Refresher {
 	ticker := time.NewTicker(interval)
 	return Refresher{
 		ticker:  ticker,
@@ -45,7 +46,7 @@ func (r Refresher) Refresh(ctx context.Context) {
 	defer cancel()
 
 	for _, domain := range r.domains {
-		if _, err := r.client.ExpireTime(ctx, domain); err != nil {
+		if _, err := r.client.ExpireTime(ctx, domain.Name, domain.Host); err != nil {
 			log.Error().Err(err).Msgf("failed to get expire time for %s", domain)
 		}
 	}

--- a/internal/refresher/refresher_test.go
+++ b/internal/refresher/refresher_test.go
@@ -5,19 +5,21 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/caarlos0/domain_exporter/internal/safeconfig"
 )
 
 type fakeOk struct {
 }
 
-func (fakeOk) ExpireTime(ctx context.Context, domain string) (time.Time, error) {
+func (fakeOk) ExpireTime(ctx context.Context, domain string, host string) (time.Time, error) {
 	return time.Time{}, nil
 }
 
 type fakeFail struct {
 }
 
-func (fakeFail) ExpireTime(ctx context.Context, domain string) (time.Time, error) {
+func (fakeFail) ExpireTime(ctx context.Context, domain string, host string) (time.Time, error) {
 	return time.Time{}, errors.New("foo")
 }
 
@@ -28,11 +30,11 @@ func Test_refresher_Refresh(t *testing.T) {
 	}{
 		{
 			name:      "refresh is ok",
-			refresher: New(time.Second, fakeOk{}, "foo.com"),
+			refresher: New(time.Second, fakeOk{}, safeconfig.Domain{Name: "foo.com", Host: ""}),
 		},
 		{
 			name:      "refresh is failed",
-			refresher: New(time.Second, fakeFail{}, "foo.com"),
+			refresher: New(time.Second, fakeFail{}, safeconfig.Domain{Name: "foo.com", Host: ""}),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/safeconfig/safeconfig.go
+++ b/internal/safeconfig/safeconfig.go
@@ -9,8 +9,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type Domain struct {
+	Name string `yaml:"name"`
+	Host string `yaml:"host,omitempty"`
+}
+
 type SafeConfig struct {
-	Domains []string `yaml:"domains"`
+	Domains []Domain `yaml:"domains"`
 }
 
 func New(pathToFile string) (SafeConfig, error) {

--- a/internal/safeconfig/safeconfig_test.go
+++ b/internal/safeconfig/safeconfig_test.go
@@ -71,7 +71,7 @@ func TestSafeConfig_Reload(t *testing.T) {
 		{
 			name: "Vaidd yaml",
 			cfg: SafeConfig{
-				Domains: []string{"google.com"},
+				Domains: []Domain{{Name: "google.com", Host: ""}},
 			},
 			fileContent: `
 domains:

--- a/internal/whois/whois.go
+++ b/internal/whois/whois.go
@@ -85,9 +85,9 @@ func NewClient() client.Client {
 	return whoisClient{}
 }
 
-func (c whoisClient) ExpireTime(ctx context.Context, domain string) (time.Time, error) {
+func (c whoisClient) ExpireTime(ctx context.Context, domain string, host string) (time.Time, error) {
 	log.Debug().Msgf("trying whois client for %q", domain)
-	body, err := c.request(ctx, domain, "")
+	body, err := c.request(ctx, domain, host)
 	if err != nil {
 		return time.Now(), err
 	}

--- a/internal/whois/whois_test.go
+++ b/internal/whois/whois_test.go
@@ -12,34 +12,35 @@ import (
 func TestWhoisParsing(t *testing.T) {
 	for _, tt := range []struct {
 		domain string
+		host   string
 		err    string
 	}{
-		{domain: "google.ai", err: "could not parse whois response"},
-		{domain: "google.lt", err: ""},
-		{domain: "fakedomain.foo", err: "Domain not found"},
-		{domain: "google.cn", err: ""},
-		{domain: "google.com", err: ""},
-		{domain: "google.de", err: "could not parse whois response"},
-		{domain: "nic.ua", err: ""},
-		{domain: "google.com.tw", err: ""},
-		{domain: "bbc.co.uk", err: ""},
-		{domain: "google.sg", err: ""},
-		{domain: "google.sk", err: ""},
-		{domain: "google.ro", err: ""},
-		{domain: "google.pt", err: "i/o timeout"},
-		{domain: "google.it", err: ""},
-		{domain: "google.pw", err: ""},
-		{domain: "google.co.id", err: ""},
-		{domain: "google.kr", err: ""},
-		{domain: "google.jp", err: ""},
-		{domain: "microsoft.im", err: ""},
-		{domain: "google.rs", err: ""},
-		{domain: "мвд.рф", err: ""},
-		{domain: "МВД.РФ", err: ""},
-		{domain: "GOOGLE.RS", err: ""},
-		{domain: "google.co.th", err: ""},
-		{domain: "google.fi", err: ""},
-		{domain: "google.host", err: ""},
+		{domain: "google.ai", host: "", err: "could not parse whois response"},
+		{domain: "google.lt", host: "", err: ""},
+		{domain: "fakedomain.foo", host: "", err: "Domain not found"},
+		{domain: "google.cn", host: "", err: ""},
+		{domain: "google.com", host: "", err: ""},
+		{domain: "google.de", host: "", err: "could not parse whois response"},
+		{domain: "nic.ua", host: "", err: ""},
+		{domain: "google.com.tw", host: "", err: ""},
+		{domain: "bbc.co.uk", host: "", err: ""},
+		{domain: "google.sg", host: "", err: ""},
+		{domain: "google.sk", host: "", err: ""},
+		{domain: "google.ro", host: "", err: ""},
+		{domain: "google.pt", host: "", err: "i/o timeout"},
+		{domain: "google.it", host: "", err: ""},
+		{domain: "google.pw", host: "", err: ""},
+		{domain: "google.co.id", host: "", err: ""},
+		{domain: "google.kr", host: "", err: ""},
+		{domain: "google.jp", host: "", err: ""},
+		{domain: "microsoft.im", host: "", err: ""},
+		{domain: "google.rs", host: "", err: ""},
+		{domain: "мвд.рф", host: "", err: ""},
+		{domain: "МВД.РФ", host: "", err: ""},
+		{domain: "GOOGLE.RS", host: "", err: ""},
+		{domain: "google.co.th", host: "", err: ""},
+		{domain: "google.fi", host: "", err: ""},
+		{domain: "google.host", host: "", err: ""},
 	} {
 		tt := tt
 		t.Run(tt.domain, func(t *testing.T) {
@@ -49,7 +50,7 @@ func TestWhoisParsing(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			t.Cleanup(cancel)
 
-			expiry, err := NewClient().ExpireTime(ctx, tt.domain)
+			expiry, err := NewClient().ExpireTime(ctx, tt.domain, tt.host)
 			if tt.err == "" {
 				is.NoErr(err)                           // expected no errors
 				is.True(time.Since(expiry).Hours() < 0) // domain must not be expired

--- a/main.go
+++ b/main.go
@@ -141,6 +141,7 @@ func probeHandler(cli client.Client) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		params := r.URL.Query()
 		target := strings.TrimPrefix(params.Get("target"), "www.")
+		host := params.Get("host")
 		if target == "" {
 			log.Error().Msg("target parameter missing")
 			http.Error(w, "target parameter is missing", http.StatusBadRequest)
@@ -148,7 +149,7 @@ func probeHandler(cli client.Client) http.HandlerFunc {
 		}
 
 		registry := prometheus.NewRegistry()
-		registry.MustRegister(collector.NewDomainCollector(cli, target))
+		registry.MustRegister(collector.NewDomainCollector(cli, safeconfig.Domain{Name: target, Host: host}))
 
 		promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP(w, r)
 	}


### PR DESCRIPTION
## Description

intended as a fix for #92 

## Details

this doesn't break backwards compatibility. we can still continue using it with old config but with this patch we have the opportunity to specify whois host per domain in special cases, like:

```
domains:
- name: google.com
- name: facebook.com
- name: some.other.domain.with.special.whois.host
  host: whois.godaddy.com
```