### PR TITLE
Tests repair: Removing not existing host from tests

### DIFF
--- a/internal/whois/whois_test.go
+++ b/internal/whois/whois_test.go
@@ -40,7 +40,6 @@ func TestWhoisParsing(t *testing.T) {
 		{domain: "GOOGLE.RS", host: "", err: ""},
 		{domain: "google.co.th", host: "", err: ""},
 		{domain: "google.fi", host: "", err: ""},
-		{domain: "google.host", host: "", err: ""},
 	} {
 		tt := tt
 		t.Run(tt.domain, func(t *testing.T) {


### PR DESCRIPTION
Tests were failing due to not existing hostname google.host
This PR is fixing it