### PR TITLE
Adding com.tr support

### DIFF
--- a/internal/whois/whois.go
+++ b/internal/whois/whois.go
@@ -53,6 +53,7 @@ var (
 		"02 Jan 2006",                 // .co.th
 		"2.1.2006 15:04:05",           // .fi
 		"02-01-2006",                  // .hk
+		"2006-Jan-02.",                // .com.tr
 	}
 
 	// nolint: lll
@@ -67,6 +68,7 @@ var (
 		"Expiration Time",
 		"Expiry date",
 		"Expiry",
+		"Expires on\\.{14}:",
 		"Expires On",
 		"expires\\.{12}",
 		"expires",

--- a/internal/whois/whois_test.go
+++ b/internal/whois/whois_test.go
@@ -42,6 +42,7 @@ func TestWhoisParsing(t *testing.T) {
 		{domain: "google.fi", host: "", err: ""},
 		{domain: "google.com.hk", host: "", err: ""},
 		{domain: "google.vn", host: "whois.net.vn", err: ""},
+		{domain: "google.com.tr", host: "", err: ""},
 	} {
 		tt := tt
 		t.Run(tt.domain, func(t *testing.T) {


### PR DESCRIPTION
Com.tr domains have different expiration time .
for example amazon.com.tr has following:
```
** Additional Info:
Created on..............: 1998-Feb-05.
Expires on..............: 2025-Feb-04.
```
With this patch adding support for these domains.
Without this fix an error is generated:
```
11:55AM ERR failed to get expire time for {amazon.com.tr } error="could not parse date: \"..............: 2025-Feb-04.\""
```