### PR TITLE
Remove skip-go-installation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,5 +16,3 @@ jobs:
         with:
           go-version: stable
       - uses: golangci/golangci-lint-action@v6
-        with:
-          skip-go-installation: true


### PR DESCRIPTION
> The `skip-go-installation` option has been removed.

https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#compatibility