### PR TITLE
rules: Add probe success evaluation

### DIFF
--- a/_examples/alerts.rules
+++ b/_examples/alerts.rules
@@ -1,5 +1,5 @@
-ALERT DomainExpiring
-  IF domain_expiry_days < 30
+ALERT DomainExpiringLessThen30Days
+  IF domain_expiry_days != -1 AND domain_expiry_days < 30 AND domain_expiry_days > 5
   FOR 1h
   LABELS {
     severity = "warning",
@@ -9,8 +9,8 @@ ALERT DomainExpiring
     summary = "{{ $labels.domain }}: domain is expiring",
   }
 
-ALERT DomainExpiring
-  IF domain_expiry_days < 5
+ALERT DomainExpiringLessThen5Days
+  IF domain_expiry_days != -1 AND domain_expiry_days <= 5
   FOR 1h
   LABELS {
     severity = "page",
@@ -18,4 +18,15 @@ ALERT DomainExpiring
   ANNOTATIONS {
     description = "Domain {{ $labels.domain }} will expire in less than 5 days",
     summary = "{{ $labels.domain }}: domain is expiring",
+  }
+
+ALERT DomainProbeFailure
+  IF domain_probe_success == 0
+  FOR 1h
+  LABELS {
+    severity = "warning",
+  }
+  ANNOTATIONS {
+    description = "Domain {{ $labels.domain }} is not valid. Cannot probe",
+    summary = "{{ $labels.domain }}: cannot probe",
   }

--- a/_examples/alerts.rules.yml
+++ b/_examples/alerts.rules.yml
@@ -1,19 +1,29 @@
 groups:
 - name: domain
   rules:
-  - alert: DomainExpiring
-    expr: domain_expiry_days < 30
+  - alert: DomainExpiringLessThen30Days
+    expr: domain_expiry_days != -1 AND domain_expiry_days < 30 AND domain_expiry_days > 5
     for: 1h
     labels:
       severity: warning
     annotations:
       description: 'Domain {{ $labels.domain }} will expire in less than 30 days'
       summary: '{{ $labels.domain }}: domain is expiring'
-  - alert: DomainExpiring
-    expr: domain_expiry_days < 5
+
+  - alert: DomainExpiringLessThen5Days
+    expr: domain_expiry_days != -1 AND domain_expiry_days <= 5
     for: 1h
     labels:
       severity: page
     annotations:
       description: 'Domain {{ $labels.domain }} will expire in less than 5 days'
       summary: '{{ $labels.domain }}: domain is expiring'
+
+  - alert: DomainProbeFailure
+    expr: domain_probe_success == 0
+    for: 1h
+    labels:
+      severity: warning
+    annotations:
+      description: 'Domain {{ $labels.domain }} is not valid. Cannot probe'
+      summary: '{{ $labels.domain }}: cannot probe'


### PR DESCRIPTION
* Check if probe was successful

* Exclude failed probe from 30 days and 5 days expiry evaluation

Changes to `alerts.rules` have been adapted to the format, but only `alerts.rules.yml`  have been tested. 