### PR TITLE
chore: fix up tests and broken adapter_vn

### DIFF
--- a/internal/whois/adapter_vn.go
+++ b/internal/whois/adapter_vn.go
@@ -30,9 +30,9 @@ func init() {
 }
 
 // Generate URL for .vn whois request.
-// Query sent to whois.net.vn should go to `/whois.php` route with `act` & `domain` parameters.
+// Query sent to whois.net.vn should go to `/checkdomain.php` route with `act` & `domain` parameters.
 func generateVnWhoisRequestUrl(query string) string {
-	whoisEndpoint := "https://whois.net.vn/whois.php?"
+	whoisEndpoint := "https://whois.net.vn/checkdomain.php?"
 
 	whoisQueryParams := url.Values{}
 	whoisQueryParams.Set("act", "getwhois")


### PR DESCRIPTION
- Changed whoisEndpoint for adapter_vn 
- Added expired check to TestWhoisParsing case 
- fakedomain.foo was returning issue with whois.nic.google "cannot resolve whois.nic.google: Unknown host"
- Added google.io to tests cases