### PR TITLE
fix: anchor expiry regex to line start to avoid matching state field …

### DIFF
--- a/internal/whois/whois.go
+++ b/internal/whois/whois.go
@@ -63,7 +63,7 @@ var (
 	}
 
 	// nolint: lll
-	expiryRE = regexp.MustCompile(`(?i)(` + strings.Join([]string{
+	expiryRE = regexp.MustCompile(`(?im)^\s*(` + strings.Join([]string{
 		"Registrar Registration Expiration Date",
 		"expire-date",
 		"Valid Until",


### PR DESCRIPTION
…values

The expiryRE regex used (?i) without multiline mode, so it could match keywords like "registered" anywhere in the whois response body, including inside field values. For example, some registrars return:

  state: REGISTERED, DELEGATED, UNVERIFIED

The regex matched "REGISTERED" inside the state value before reaching the actual expiry field, capturing ", DELEGATED, UNVERIFIED" as the date string, which then failed to parse.

Adding (?m) flag and ^\s* anchors the match to the beginning of each line, ensuring only field names are matched, not their values.