### PR TITLE
fix: route /probe handler through cachedClient

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func main() {
 	}
 
 	http.Handle("/metrics", promhttp.Handler())
-	http.HandleFunc("/probe", probeHandler(cli))
+	http.HandleFunc("/probe", probeHandler(cachedClient))
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprintf(
 			w, `


### PR DESCRIPTION
## Why

`/probe` currently uses the uncached `MultiClient` directly:

```go
http.HandleFunc("/probe", probeHandler(cli))
```

while `/metrics` (for static-configured domains) goes through `cachedClient`.

Deployments using HTTP service discovery (httpSD) where Prometheus scrapes `/probe?target=<domain>` therefore bypass the cache entirely and call RDAP+WHOIS upstream on every scrape interval (e.g. once every 2 minutes per discovered domain). With many discovered domains this generates hundreds of upstream queries per hour from a single source IP.

For TLDs with strict per-IP throttling — notably `.io` via Identity Digital — this trips the abuse-protection threshold and both RDAP and WHOIS start returning timeouts to the source IP. Once throttled, every subsequent probe also fails, nothing gets cached (the cache layer only stores successes), and `domain_expiry_days` stays at `-1` for hours until the threshold resets *and* the offending IP stops querying long enough.

We hit this with five `.io` zones from one cluster: probes failed for ~13 hours, the bundled `DomainExporterProbeFailed` rule fired, and we couldn't tell whether domains were actually expiring or upstream was just throttled.

## What

Route `/probe` through the same `cachedClient` already used by `/metrics`:

```diff
-	http.HandleFunc("/probe", probeHandler(cli))
+	http.HandleFunc("/probe", probeHandler(cachedClient))
```

After the first successful response, subsequent probes are served from cache for the configured `--cache` TTL (default 2h). Live upstream calls collapse from `scrape_interval × num_domains` to roughly `1 / cache_ttl × num_domains`, which stays well below per-IP throttle thresholds.

## Notes

- No behavior change for static-configured domains (`/metrics` already uses `cachedClient`).
- No behavior change for users without httpSD (the unchanged path was just a missed `cachedClient` reference, not an intentional cache bypass).
- Tested on our fork at v1.24.1 in production for `.io` zones discovered via httpSD.

Happy to add a regression test if you'd like one.