### PR TITLE
rdap: override server for TLDs missing from IANA bootstrap (e.g. .io)

### DIFF
--- a/internal/rdap/rdap.go
+++ b/internal/rdap/rdap.go
@@ -3,12 +3,29 @@ package rdap
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/caarlos0/domain_exporter/internal/client"
 	"github.com/openrdap/rdap"
 	"github.com/rs/zerolog/log"
 )
+
+// rdapServerOverrides maps TLDs whose RDAP server isn't in IANA's bootstrap
+// (https://data.iana.org/rdap/dns.json) to a known RDAP endpoint. The
+// openrdap library only consults the IANA registry, so without an override
+// it returns "No RDAP servers found" for these TLDs even though the
+// registry operator publishes a working RDAP service.
+//
+// .io and other Identity Digital TLDs deprecated WHOIS port 43 on
+// 2025-08-04 and migrated to RDAP-only, but the IANA bootstrap entry
+// hasn't been updated to point at rdap.identitydigital.services.
+//
+// nolint: gochecknoglobals
+var rdapServerOverrides = map[string]string{
+	"io": "https://rdap.identitydigital.services/rdap/",
+}
 
 // nolint: gochecknoglobals
 var (
@@ -57,6 +74,14 @@ func (rdapClient) ExpireTime(ctx context.Context, domain string, host string) (t
 	req := &rdap.Request{
 		Type:  rdap.DomainRequest,
 		Query: domain,
+	}
+	if i := strings.LastIndex(domain, "."); i >= 0 {
+		if override, ok := rdapServerOverrides[domain[i+1:]]; ok {
+			if srv, err := url.Parse(override); err == nil {
+				req.Server = srv
+				log.Debug().Msgf("using rdap server override %s for %s", override, domain)
+			}
+		}
 	}
 	req = req.WithContext(ctx)
 


### PR DESCRIPTION
## Why

The openrdap library exclusively consults IANA's RDAP bootstrap registry at https://data.iana.org/rdap/dns.json for TLD-to-server discovery. Some registry operators run a working RDAP service but haven't been added to the IANA registry yet — for those TLDs, every lookup fails with `No RDAP servers found for $domain.$tld` and the exporter falls through to WHOIS.

The motivating case is `.io`. Identity Digital deprecated WHOIS port 43 on 2025-08-04 and migrated all their TLDs (`.io`, `.sh`, `.ac`, `.me`, etc.) to RDAP-only at `rdap.identitydigital.services`. As of today the IANA bootstrap registry has 591 TLD entries but no `.io` entry — so the exporter can't probe any `.io` domain via either path:

- RDAP via openrdap → "No RDAP servers found"
- WHOIS port 43 → connection timeouts (service decommissioned)

Result: `domain_expiry_days` stays at `-1` for every `.io` domain until the IANA registry is updated. We hit this in production with five `.io` zones.

## What

Maintain a small `TLD → RDAP server URL` override map in `internal/rdap/rdap.go`. If the domain's TLD has an entry, set `req.Server` before calling `client.Do`, which bypasses bootstrap for that lookup. Other domains are unaffected — bootstrap is still used everywhere else.

```diff
+var rdapServerOverrides = map[string]string{
+    "io": "https://rdap.identitydigital.services/rdap/",
+}
+
 func (rdapClient) ExpireTime(...) (time.Time, error) {
     log.Debug().Msgf("trying rdap client for %s", domain)
     req := &rdap.Request{Type: rdap.DomainRequest, Query: domain}
+    if i := strings.LastIndex(domain, "."); i >= 0 {
+        if override, ok := rdapServerOverrides[domain[i+1:]]; ok {
+            if srv, err := url.Parse(override); err == nil {
+                req.Server = srv
+            }
+        }
+    }
     ...
 }
```

Verified manually with `openrdap@v0.9.1`: `maestra.io` returns expiry `2028-09-05` with this change applied (vs. `No RDAP servers found for 'maestra.io'` without).

## Notes

- Map seeded with `.io` only — that's what we hit. Other Identity Digital TLDs (`.sh`, `.ac`, `.me`, `.pw`, `.co`, ...) and any future bootstrap gaps can be added without restructuring.
- Pre-existing test failures for `google.sg` / `taiwannews.com.tw` (unchanged by this PR) appear to be IANA registry drift — those tests assert "No RDAP servers found" but those TLDs now have entries and succeed.
- This is independent of #408 (cache `/probe` handler). Both fix `.io` problems but at different layers.